### PR TITLE
msm: ipa: Move NAT invalid protocol define to uapi

### DIFF
--- a/include/uapi/linux/msm_ipa.h
+++ b/include/uapi/linux/msm_ipa.h
@@ -36,6 +36,11 @@
 #define IPA_DFLT_RT_TBL_NAME "ipa_dflt_rt"
 
 /**
+ * name for default value of invalid protocol of NAT
+ */
+#define IPAHAL_NAT_INVALID_PROTOCOL   0xFF
+
+/**
  * commands supported by IPA driver
  */
 #define IPA_IOCTL_ADD_HDR                       0


### PR DESCRIPTION
NAT invalid protocol is needed by user space process.
Move it to uapi to make it accessible to user space.

Change-Id: I4d1700176483c93f78f48979d602f7568867b378
Acked-by: Michal Amsterdam <mamsterd@qti.qualcomm.com>
Signed-off-by: Amir Levy <alevy@codeaurora.org>
Signed-off-by: celtare21 <celtare21@gmail.com>